### PR TITLE
More explicit arity, and enhance form name/value encoding

### DIFF
--- a/lib/foxycart_helpers/product_verification.rb
+++ b/lib/foxycart_helpers/product_verification.rb
@@ -3,12 +3,12 @@ require 'foxycart_helpers/configuration'
 module FoxycartHelpers
   class ProductVerification
 
-    def self.encode(*args)
-      new(*args).encode
+    def self.encode(code, name, value)
+      new(code, name, value).encode
     end
 
-    def self.encoded_name(*args)
-      new(*args).encoded_name
+    def self.encoded_name(code, name, value)
+      new(code, name, value).encoded_name
     end
 
     def encode

--- a/spec/foxycart_helpers/product_verification_spec.rb
+++ b/spec/foxycart_helpers/product_verification_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+
+module FoxycartHelpers
+  describe ProductVerification, '.encode' do
+    before do
+      FoxycartHelpers.configure do |config|
+        config.api_key = 'foobarbat'
+      end
+    end
+
+    after do
+      FoxycartHelpers.configure do |config|
+        config.api_key = nil
+      end
+    end
+
+    context 'with a normal name value' do
+      it 'encodes code, name value with api key' do
+        code = 'SKU123'
+        name = 'name'
+        value = 'My product'
+
+        result = FoxycartHelpers::ProductVerification.encode(code, name, value)
+
+        expect(result).to eq '75962bb014c9afce78224d30ed349cc0a34e6f1a304f94695d5192daebb3d560'
+      end
+    end
+
+    context 'with a numeric prefix' do
+      it 'removes prefix before encoding' do
+        code = 'SKU123'
+        name = '2:name'
+        value = 'My product'
+
+        result = FoxycartHelpers::ProductVerification.encode(code, name, value)
+
+        # expect result to be identical to previous test
+        expect(result).to eq '75962bb014c9afce78224d30ed349cc0a34e6f1a304f94695d5192daebb3d560'
+      end
+    end
+  end
+
+  describe ProductVerification, '.encoded_name' do
+    before do
+      FoxycartHelpers.configure do |config|
+        config.api_key = 'foobarbat'
+      end
+    end
+
+    after do
+      FoxycartHelpers.configure do |config|
+        config.api_key = nil
+      end
+    end
+
+    it 'generates an encoded name' do
+      code = 'SKU123'
+      name = 'name'
+      value = 'My product'
+
+      result = FoxycartHelpers::ProductVerification.encoded_name(code, name, value)
+
+      expect(result).to eq 'name||75962bb014c9afce78224d30ed349cc0a34e6f1a304f94695d5192daebb3d560'
+    end
+
+    it 'generates an encoded value' do
+      code = 'SKU123'
+      name = 'name'
+      value = 'My product'
+
+      result = FoxycartHelpers::ProductVerification.encoded_value(code, name, value)
+
+      expect(result).to eq 'My product||75962bb014c9afce78224d30ed349cc0a34e6f1a304f94695d5192daebb3d560'
+    end
+
+    it 'generates an "--OPEN--" name' do
+      code = 'SKU123'
+      name = 'quantity'
+      value = '--OPEN--'
+
+      result = FoxycartHelpers::ProductVerification.encoded_name(code, name, value)
+
+      expect(result).to eq 'quantity||1782f0f0c213887709d71af1788c270eb91bc231e0461e95c062bfa5a083a90b||open'
+    end
+  end
+end


### PR DESCRIPTION
Hello Robert! 👋 😄 

Have a PR here I'd love for you to consider. I just started integrating foxycart in a new ecommerce site and have a few (edge) use cases that don't fit in with the stock examples foxycart provides, and are not entirely accounted for in your `ProductVerification` class. As a result I've added some updates and some backing tests. Commit comments follow:

---
### More explicit method signature

For other developers coming into this class there may be some negligible benefits for passing class method params on to instance methods with a splat if the method signatures are identical and not  comprised of parameters that could change based on the content.

In other words - "don't make me work more than I need to" 😉 

This commit is, essentially, a request to make those class method parameters more explicit and offload the cognitive work of tracking down the method signature(s) of the instance method.
### Split encoded value and name. Add specs.

Based on the documentation in the [foxycart wiki](https://wiki.foxycart.com/v/2.0/hmac_validation#an_example) there is some differing behavior based on when the value and name are being assigned the encoded HMAC data. Specifically:
- When there is a numeric prefix to the form name the encoded data should not use `<number>:`.
- When the value is an OPEN value, the result should contain "||open" appended to the end.
- Etc ...

To keep track of these cases I've added some tests for both "CYA" test coverage, and documentation purposes. It's easier to reason the edge cases when we can hold up the example inputs against the results.

---

Huge thanks for the rubygem, by the way. It's going to be super duper helpful!
