### PR TITLE
Use class object instead of string for newer Rails

### DIFF
--- a/lib/foxycart_helpers/product_verification.rb
+++ b/lib/foxycart_helpers/product_verification.rb
@@ -1,4 +1,5 @@
 require 'foxycart_helpers/configuration'
+require 'openssl'
 
 module FoxycartHelpers
   class ProductVerification

--- a/lib/foxycart_helpers/railtie.rb
+++ b/lib/foxycart_helpers/railtie.rb
@@ -5,7 +5,7 @@ module FoxycartHelpers
   class Railtie < Rails::Railtie
 
     initializer 'foxycart_helpers.use_rack_middleware' do |app|
-      app.config.middleware.use 'FoxycartHelpers::Middleware'
+      app.config.middleware.use FoxycartHelpers::Middleware
     end
 
     initializer 'foxycart_helpers.configure_view_controller' do |app|


### PR DESCRIPTION
When upgrading to Rails 5.1.4 I ran into an issue where adding the
FoxycartHelpers middleware resulted in an exception. This commit detects
the rails version and will react appropriately so as to maintain
expected behavior for previous versions of rails.

Also - explicitly require OpenSSL in order for the test suite to get
back to passing!